### PR TITLE
Enable posibility to run qmc.sh from other directories

### DIFF
--- a/linux64/bin/qmc.sh
+++ b/linux64/bin/qmc.sh
@@ -1,20 +1,16 @@
-#!/bin/sh
+#!/bin/bash
 
 # find directory of this wrapper
-dirname="$(dirname "$(readlink "${0}")")"
-tmp="${dirname#?}"
+SCRIPT=$(readlink -f "$0") 	# Absolute path to this script, e.g. /home/user/bin/foo.sh
+SCRIPTPATH=$(dirname "$SCRIPT") # Absolute path this script is in, thus /home/user/bin
 
-if [ "${dirname%$tmp}" != "/" ]; then
-  dirname="${PWD}/${dirname}"
-fi
-
-# add dirname (in front of LD_LIBRARY_PATH)
+# add SCRIPTPATH (in front of LD_LIBRARY_PATH)
 if [ "${LD_LIBRARY_PATH}" ]; then
-  LD_LIBRARY_PATH="${dirname}:${LD_LIBRARY_PATH}"
+  LD_LIBRARY_PATH="${SCRIPTPATH}:${LD_LIBRARY_PATH}"
 else
-  LD_LIBRARY_PATH="${dirname}"
+  LD_LIBRARY_PATH="${SCRIPTPATH}"
 fi  
 export LD_LIBRARY_PATH
 
 # replace this wrapper script with qmc + args
-exec "${dirname}/qmc"  "$@"
+exec "${SCRIPTPATH}/qmc"  "$@"


### PR DESCRIPTION
At the moment I can only run the `qmc.sh` script when I do it from the `bin` directory where it is placed. If you try to run it from other directory I get this error:

```
myUser@:~/someOfMyDirectories/$ /opt/qm/bin/qmc.sh
/opt/qm/bin/qmc.sh: 20: exec: /someOfMyDirectories/./qmc: not found
```

The script shows the intention to implement the possibility to be able to run the script from any folder, but I think it was not properly implemented/tested.